### PR TITLE
Update markdown-link-check-config.json

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -18,6 +18,10 @@
     {
       "pattern": "^%20https://",
       "reason": "Malformed URLs with spaces at the beginning"
+    },
+    {
+      "pattern": "^https://github.com/team-mirai/policy/pulls$",
+      "reason": "Avoid to get 406 response"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Avoid to get 406 response

GitHubから406レスポンスが帰ってきてリンクチェッカーがまともに動かなくなっていたので、除外条件に入れてみました。