### PR TITLE
Add GitHub Pulls list pages to ignorePatterns

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -18,6 +18,10 @@
     {
       "pattern": "^%20https://",
       "reason": "Malformed URLs with spaces at the beginning"
+    },
+    {
+      "pattern": "^https://github\\.com/[^/]+/[^/]+/pulls",
+      "reason": "Avoid 406 error"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
pullsページは `Accept: application/vnd.github.v3+json` を指定していると406エラーを返すので、リンクチェックから除外する。

Fix #181