### PR TITLE
CI: fix 406 error of GitHub links

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -26,15 +26,6 @@
       "replacement": "{{BASEURL}}/"
     }
   ],
-  "httpHeaders": [
-    {
-      "urls": ["https://github.com/", "https://raw.githubusercontent.com/"],
-      "headers": {
-        "Accept": "application/vnd.github.v3+json",
-        "User-Agent": "GitHub-Link-Checker"
-      }
-    }
-  ],
   "timeout": "10s",
   "retryOn429": true,
   "retryCount": 3,


### PR DESCRIPTION
* Fix #181

`application/vnd.github.v3+json` is MIME type for API.
It appears that it is wrongly used for normal links check.

今CIが落ちている原因は`application/vnd.github.v3+json`というAPI用のメディアタイプを指定してしまっているからだと思います。

元々の設定の意図が分かっていませんが、通常のリンクを確認するだけならこの設定自体が必要ないんじゃないか、と思った次第です。

もし設定の意図があれば、まるごと消すのは誤りである可能性があるので、クローズしていただければと思います。