### PR TITLE
「変更提案について」の表現修正（README.md）

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 本マニフェストによる変更提案は２つの形で受付をしています。
 
 * [こちら](https://policy.team-mir.ai/view/README.md)のページから、チャットで政策要望を提出する  
-* （玄人向け）[GitHub](https://github.com/team-mirai/policy/pulls)でPull Requestを提出する
+* [GitHub](https://github.com/team-mirai/policy/pulls)でPull Requestを提出する
 
 　頂いた変更提案は、チームみらいが責任をもって確認します。変更提案をマニフェストに反映させるかどうかについては、チームみらいが権限を持ちます。当初マニフェストとは異なる方向性の提案であっても、真剣に検討し、反映するかどうかを考えます。
 


### PR DESCRIPTION
【修正前】
本マニフェストによる変更提案は２つの形で受付をしています。

こちらのページから、チャットで政策要望を提出する
（玄人向け）GitHubでPull Requestを提出する

【修正案】
本マニフェストによる変更提案は２つの形で受付をしています。

こちらのページから、チャットで政策要望を提出する
GitHubでPull Requestを提出する

【修正の意図】
GitHubの前の（玄人向け）という表記を消しました。GitHubが「玄人向け」というのは同時に、チャット形式がその対義語として「素人」を連想させるように思います。GitHubが馴染みがない人が多いのでGitHubに注釈を加えたい意図は理解しますが、このような書き方はテクノロジーの「玄人」の「素人」に人を区分するようなニュアンスを感じるふさわしくないと感じます。むしろテクノロジーによって、技術テクノロジーの「素人」も「玄人」も分け隔てなくマニフェスト修正にアクセスできるというものがチームみらいのアピールすべき目指す社会の姿ではないでしょうか？そのためにこの表記は修正すべきです。