### PR TITLE
改善: X投稿通知の条件を最適化

### DIFF
--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -4,16 +4,16 @@ on:
   pull_request_target:
     types: [closed]
     branches: [main]
-    paths-ignore:
-      - '.github/**'
-      - '.tools/**'
-      - '.meta/**'
+    paths:
+      - '[0-9]*.md'
 
 jobs:
   post-to-x:
     runs-on: ubuntu-latest
-    # マージされたPRのみX投稿を実行する
-    if: github.event.pull_request.merged == true
+    # マージされたPRのみX投稿を実行する（skip-notificationラベルがついていない場合）
+    if: |
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-notification')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
- 通知対象を政策ファイル（数字で始まるMarkdownファイル）のみに限定
- `skip-notification`ラベルがついたPRは通知対象から除外

## 背景
現在の設定では、README.mdやLICENSEなどのシステムファイルの変更でもツイートされてしまいます。また、タイポ修正などの軽微な変更も通知されるため、政策提案の実質的な変更のみが通知されるよう条件を最適化しました。

## 変更内容
1. `paths-ignore`から`paths`に変更し、数字で始まるMarkdownファイル（`[0-9]*.md`）のみを対象に
2. `skip-notification`ラベルがついたPRは通知をスキップする条件を追加

## テスト方法
- [ ] 政策ファイル（例：`01_チームみらいのビジョン.md`）の変更をマージ → 通知される
- [ ] READMEなどのシステムファイルの変更をマージ → 通知されない
- [ ] `skip-notification`ラベル付きの政策ファイル変更をマージ → 通知されない

🤖 Generated with [Claude Code](https://claude.ai/code)