### PR TITLE
fix: フォークからのPRでコメント通知が失敗する問題を修正

### DIFF
--- a/.github/workflows/pr-comment-notification-info.yml
+++ b/.github/workflows/pr-comment-notification-info.yml
@@ -1,7 +1,7 @@
 name: PR Comment for Notification Info
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths:
       - '[0-9]*.md'


### PR DESCRIPTION
## 概要
フォークされたリポジトリからのPRでコメント通知のGitHub Actionsが `Resource not accessible by integration` エラーで失敗する問題を修正しました。

## 変更内容
`.github/workflows/pr-comment-notification-info.yml` のトリガーイベントを `pull_request` から `pull_request_target` に変更

## 原因と解決策
- **原因**: `pull_request` イベントはフォークのコンテキストで実行されるため、メインリポジトリへのコメント投稿権限がない
- **解決**: `pull_request_target` を使用することで、ベースリポジトリの権限で実行されるようになる

## 注意事項
- この変更がマージされるまで、フォークからのPRではエラーが継続します
- マージ後は、フォークからのPRでも正常にコメントが投稿されるようになります
- セキュリティ面では、ワークフローがPRのコードを実行しないため安全です

## テスト方法
1. この変更をマージ
2. フォークからテストPRを作成
3. コメントが正常に投稿されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)